### PR TITLE
Automatic cache invalidation by set expiration interval

### DIFF
--- a/custom_components/ica/caching.py
+++ b/custom_components/ica/caching.py
@@ -4,22 +4,28 @@ from pathlib import Path
 import asyncio
 import json
 import logging
+import datetime as dt
+from typing import Generic, Any, TypeVar
 
 from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
 
 from .utils import EmptyLogger
+from .const import CACHING_SECONDS_LONG_TERM
 
 STORAGE_PATH = ".storage/ica.{key}.json"
 
+_DataT = TypeVar("_DataT", default=dict[str, Any])
 
-class CacheEntry:
+
+class CacheEntry(Generic[_DataT]):
     def __init__(
         self,
         hass: HomeAssistant,
         key: str,
         value_factory,
-        persistToFile: bool = True,
+        expiry_seconds: int = CACHING_SECONDS_LONG_TERM,
+        persist_to_file: bool = True,
         logger: logging.Logger = None,
     ) -> None:
         # Example: CacheEntry(hass, f"{self._config_entry.data[CONF_ICA_ID]}.baseitems")
@@ -27,24 +33,47 @@ class CacheEntry:
         self._key = key
         self._path = Path(self._hass.config.path(STORAGE_PATH.format(key=slugify(key))))
         self._file: LocalFile | None = None
-        self._value = None
+        self._value: _DataT = None
         self._value_factory = value_factory
         self._logger: logging.Logger = logger or EmptyLogger()
+        self._timestamp: dt.datetime | None = None
+        self._expiry_seconds: int = expiry_seconds
 
-        if persistToFile:
+        if persist_to_file:
             self._file = LocalFile(self._hass, self._path)
 
-    def current_value(self) -> object:
+    def current_value(self) -> _DataT:
         """Gets the current value from state. Without checking file or API.
         This can be used where async/await is not possible"""
         return self._value
 
-    async def get_value(self, invalidate_cache: bool = False) -> object:
+    async def get_value(self, invalidate_cache: bool | None = None) -> _DataT:
         """Gets value from state, file or API"""
-        if (invalidate_cache or not self._value) and self._file:
-            # Load persisted file
-            self._value = await self._file.async_load_json()
-            self._logger.debug("Loaded from file: %s = %s", self._path, self._value)
+        now = dt.datetime.now()
+
+        if not self._value and self._file:
+            # Load persisted file (if initial load)
+            content = await self._file.async_load_json()
+            self._logger.debug("Loaded from file: %s = %s", self._path, content)
+            if (
+                content
+                and isinstance(content, dict)
+                and content.get("timestamp")
+                and content.get("value")
+            ):
+                # Is wrapped in CacheEntryInfo
+                self._value = content.get("value")
+                self._timestamp = dt.datetime.fromisoformat(content.get("timestamp"))
+            else:
+                self._value = content
+
+        # Auto invalidate if passed expiry
+        invalidate_cache = (
+            not self._timestamp
+            or now > (self._timestamp + dt.timedelta(seconds=self._expiry_seconds))
+            if invalidate_cache is None
+            else invalidate_cache
+        )
 
         if invalidate_cache or not self._value:
             return await self.refresh()
@@ -54,13 +83,28 @@ class CacheEntry:
         """Refreshes state using the value_factory"""
         # Invoke value factory (example: API)
         self._value = await self._value_factory()
+        self._timestamp = dt.datetime.now()
         self._logger.debug("Loaded from factory: %s", self._value)
 
         if self._file:
             # Persist new value to file
-            await self._file.async_store_json(self._value)
-            self._logger.debug("Saved to file: %s = %s", self._path, self._value)
+            # info = CacheEntryInfo(self._value, self._timestamp)
+            info = {
+                "timestamp": str(self._timestamp),
+                "key": self._key,
+                "value": self._value,
+            }
+            await self._file.async_store_json(info)
+            self._logger.debug("Saved to file: %s = %s", self._path, info)
         return self._value
+
+
+class CacheEntryInfo(Generic[_DataT]):
+    """Cache entry metadata wrapper"""
+
+    def __init__(self, value: _DataT, timestamp: dt.datetime):
+        self.value = value
+        self.timestamp = timestamp
 
 
 class LocalFile:

--- a/custom_components/ica/caching.py
+++ b/custom_components/ica/caching.py
@@ -5,7 +5,7 @@ import asyncio
 import json
 import logging
 import datetime as dt
-from typing import Generic, Any, TypeVar
+from typing import Generic, Any, TypeVar, TypedDict
 
 from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
@@ -19,6 +19,8 @@ _DataT = TypeVar("_DataT", default=dict[str, Any])
 
 
 class CacheEntry(Generic[_DataT]):
+    """Handles automatic caching for a data provider."""
+
     def __init__(
         self,
         hass: HomeAssistant,
@@ -62,8 +64,9 @@ class CacheEntry(Generic[_DataT]):
                 and content.get("value")
             ):
                 # Is wrapped in CacheEntryInfo
-                self._value = content.get("value")
-                self._timestamp = dt.datetime.fromisoformat(content.get("timestamp"))
+                info: CacheEntryInfo = content
+                self._value = info.get("value")
+                self._timestamp = dt.datetime.fromisoformat(info.get("timestamp"))
             else:
                 self._value = content
 
@@ -89,7 +92,7 @@ class CacheEntry(Generic[_DataT]):
         if self._file:
             # Persist new value to file
             # info = CacheEntryInfo(self._value, self._timestamp)
-            info = {
+            info: CacheEntryInfo = {
                 "timestamp": str(self._timestamp),
                 "key": self._key,
                 "value": self._value,
@@ -99,12 +102,12 @@ class CacheEntry(Generic[_DataT]):
         return self._value
 
 
-class CacheEntryInfo(Generic[_DataT]):
+class CacheEntryInfo(TypedDict):
     """Cache entry metadata wrapper"""
 
-    def __init__(self, value: _DataT, timestamp: dt.datetime):
-        self.value = value
-        self.timestamp = timestamp
+    timestamp: str
+    key: str
+    value: list | dict
 
 
 class LocalFile:

--- a/custom_components/ica/caching.py
+++ b/custom_components/ica/caching.py
@@ -51,7 +51,7 @@ class CacheEntry(Generic[_DataT]):
 
     async def get_value(self, invalidate_cache: bool | None = None) -> _DataT:
         """Gets value from state, file or API"""
-        now = dt.datetime.now()
+        now = dt.datetime.utcnow()
 
         if not self._value and self._file:
             # Load persisted file (if initial load)
@@ -86,14 +86,14 @@ class CacheEntry(Generic[_DataT]):
         """Refreshes state using the value_factory"""
         # Invoke value factory (example: API)
         self._value = await self._value_factory()
-        self._timestamp = dt.datetime.now()
+        self._timestamp = dt.datetime.utcnow()
         self._logger.debug("Loaded from factory: %s", self._value)
 
         if self._file:
             # Persist new value to file
             # info = CacheEntryInfo(self._value, self._timestamp)
             info: CacheEntryInfo = {
-                "timestamp": str(self._timestamp),
+            "timestamp": self._timestamp.isoformat(),
                 "key": self._key,
                 "value": self._value,
             }

--- a/custom_components/ica/caching.py
+++ b/custom_components/ica/caching.py
@@ -51,7 +51,7 @@ class CacheEntry(Generic[_DataT]):
 
     async def get_value(self, invalidate_cache: bool | None = None) -> _DataT:
         """Gets value from state, file or API"""
-        now = dt.datetime.utcnow()
+        now = dt.datetime.now(dt.timezone.utc)
 
         if not self._value and self._file:
             # Load persisted file (if initial load)
@@ -86,14 +86,14 @@ class CacheEntry(Generic[_DataT]):
         """Refreshes state using the value_factory"""
         # Invoke value factory (example: API)
         self._value = await self._value_factory()
-        self._timestamp = dt.datetime.utcnow()
+        self._timestamp = dt.datetime.now(dt.timezone.utc)
         self._logger.debug("Loaded from factory: %s", self._value)
 
         if self._file:
             # Persist new value to file
             # info = CacheEntryInfo(self._value, self._timestamp)
             info: CacheEntryInfo = {
-            "timestamp": self._timestamp.isoformat(),
+                "timestamp": self._timestamp.isoformat(),
                 "key": self._key,
                 "value": self._value,
             }

--- a/custom_components/ica/const.py
+++ b/custom_components/ica/const.py
@@ -91,6 +91,8 @@ CONF_JSON_DATA_IN_DESC: Final = "json_data_in_desc"
 CONF_MENU_MANAGE_SHOPPING_LISTS: Final = "manage_tracked_shopping_lists"
 
 DEFAULT_SCAN_INTERVAL: Final = 5
+CACHING_SECONDS_SHORT_TERM: Final = 300  # 5 minutes
+CACHING_SECONDS_LONG_TERM: Final = 86400  # 24 hours
 
 AUTH_TICKET: Final = "AuthenticationTicket"
 GET_LISTS: Final = "ShoppingLists"


### PR DESCRIPTION
## Summary by Sourcery

Implements automatic cache invalidation based on a set expiration interval for the ICA integration. This ensures that data is refreshed periodically, preventing stale information from being displayed.

Enhancements:
- Adds an expiry time to cached data, invalidating the cache after the set time has passed.
- Updates the cache entry to store a timestamp and metadata along with the cached value.
- Sets a short-term caching time of 5 minutes for shopping lists.