### PR TITLE
Refresh login when got 401 during data update

### DIFF
--- a/custom_components/ica/icaapi.py
+++ b/custom_components/ica/icaapi.py
@@ -59,8 +59,8 @@ class IcaAPI:
         )
         self._authenticator = IcaAuthenticator(credentials, auth_state, session)
 
-    def ensure_login(self):
-        auth_state = self._authenticator.ensure_login()
+    def ensure_login(self, refresh: bool | None = None):
+        auth_state = self._authenticator.ensure_login(refresh=refresh)
         self._auth_state = auth_state
         self._auth_key = auth_state["token"]["access_token"]
 

--- a/custom_components/ica/icaapi_async.py
+++ b/custom_components/ica/icaapi_async.py
@@ -32,8 +32,8 @@ class IcaAPIAsync:
         self._auth_state = auth_state
         self._api = IcaAPI(self._credentials, self._auth_state)
 
-    async def ensure_login(self):
-        return await run_async(lambda: self._api.ensure_login())
+    async def ensure_login(self, refresh: bool | None = None):
+        return await run_async(lambda: self._api.ensure_login(refresh=refresh))
 
     def get_authenticated_user(self):
         return self._api.get_authenticated_user()


### PR DESCRIPTION
## Summary by Sourcery

Implement automatic login refresh mechanism when encountering a 401 unauthorized error during data updates

New Features:
- Add capability to automatically refresh login when receiving a 401 unauthorized response during data synchronization

Bug Fixes:
- Prevent data update failures by automatically re-authenticating when token becomes invalid

Enhancements:
- Extend authentication methods to support explicit login refresh
- Modify data coordinator to handle authentication errors more gracefully