### PR TITLE
Invalidate cache on config flow change

### DIFF
--- a/custom_components/ica/__init__.py
+++ b/custom_components/ica/__init__.py
@@ -11,7 +11,6 @@ from .icaapi_async import IcaAPIAsync
 from .coordinator import IcaCoordinator
 from .services import setup_global_services
 from .const import (
-    CONF_DIRTY_CACHE,
     DOMAIN,
     CONF_ICA_PIN,
     CONF_ICA_ID,
@@ -55,10 +54,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         update_interval,
         api,
     )
-    if entry.data.get(CONF_DIRTY_CACHE, False):
-        await coordinator.refresh_data(invalidate_cache=True)
-    else:
-        await coordinator.init_cache()
+    await coordinator.init_cache()
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})

--- a/custom_components/ica/__init__.py
+++ b/custom_components/ica/__init__.py
@@ -10,7 +10,13 @@ from homeassistant.core import HomeAssistant
 from .icaapi_async import IcaAPIAsync
 from .coordinator import IcaCoordinator
 from .services import setup_global_services
-from .const import DOMAIN, CONF_ICA_PIN, CONF_ICA_ID, DEFAULT_SCAN_INTERVAL
+from .const import (
+    CONF_DIRTY_CACHE,
+    DOMAIN,
+    CONF_ICA_PIN,
+    CONF_ICA_ID,
+    DEFAULT_SCAN_INTERVAL,
+)
 from .icatypes import AuthCredentials, AuthState
 
 _LOGGER = logging.getLogger(__name__)
@@ -49,7 +55,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         update_interval,
         api,
     )
-    await coordinator.init_cache()
+    if entry.data.get(CONF_DIRTY_CACHE, False):
+        await coordinator.refresh_data(invalidate_cache=True)
+    else:
+        await coordinator.init_cache()
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})

--- a/custom_components/ica/background_worker.py
+++ b/custom_components/ica/background_worker.py
@@ -84,7 +84,9 @@ class BackgroundWorker:
     def fire_event(self, event_type, event_data) -> None:
         """Immediately tells Home Assistant to fire an event."""
         _LOGGER.info(
-            "ICA - FIRING EVENT: %s, len: %s", event_type, len(str(event_data))
+            "ICA - FIRING EVENT: %s, len: %s",
+            event_type,
+            len(bytes(str(event_data), "utf-8")),
         )
         _LOGGER.warning("Event data: %s", str(event_data)[:100])
         self._hass.bus.fire(

--- a/custom_components/ica/const.py
+++ b/custom_components/ica/const.py
@@ -85,6 +85,7 @@ CONFIG_ENTRY_NAME: Final = "ICA - %s"
 CONF_ICA_ID: Final = "personal_id"
 CONF_ICA_PIN: Final = "pin_code"
 CONF_SHOPPING_LISTS: Final = "shopping_lists"
+CONF_DIRTY_CACHE: Final = "dirty_cache"
 CONF_NUM_RECIPES: Final = "recipe_count"
 
 CONF_JSON_DATA_IN_DESC: Final = "json_data_in_desc"

--- a/custom_components/ica/coordinator.py
+++ b/custom_components/ica/coordinator.py
@@ -528,7 +528,10 @@ class IcaCoordinator(DataUpdateCoordinator[list[IcaShoppingListEntry]]):
 
     async def _async_update_data(self) -> None:
         """Fetch data from the ICA API."""
-        await self.refresh_data()
+        if self._config_entry.data.get(CONF_DIRTY_CACHE, False):
+            await self.refresh_data(invalidate_cache=True)
+        else:
+            await self.refresh_data()
 
     def _try_persist_new_state(
         self,


### PR DESCRIPTION
## Summary by Sourcery

Implement a mechanism to invalidate cache when configuration changes occur, ensuring data freshness and consistency in the ICA integration

New Features:
- Add a new configuration flag 'dirty_cache' to track when cache needs invalidation

Enhancements:
- Modify data refresh mechanism to handle cache invalidation
- Update config flow to detect and trigger cache invalidation when shopping lists or other settings change

Chores:
- Refactor state persistence method to support additional configuration state